### PR TITLE
feat: add force revocable parameter to token endpoints

### DIFF
--- a/artifactory.go
+++ b/artifactory.go
@@ -33,6 +33,7 @@ type baseConfiguration struct {
 	AccessToken       string `json:"access_token"`
 	ArtifactoryURL    string `json:"artifactory_url"`
 	UseExpiringTokens bool   `json:"use_expiring_tokens,omitempty"`
+	ForceRevocable    *bool  `json:"force_revocable,omitempty"`
 }
 
 type errorResponse struct {
@@ -146,9 +147,12 @@ func (b *backend) createToken(config baseConfiguration, expiresIn time.Duration,
 
 	if config.UseExpiringTokens && b.supportForceRevocable() && expiresIn > 0 {
 		request.ExpiresIn = int64(expiresIn.Seconds())
-		request.ForceRevocable = true
+		if config.ForceRevocable != nil {
+			request.ForceRevocable = *config.ForceRevocable
+		} else {
+			request.ForceRevocable = true
+		}
 	}
-
 	u, err := url.Parse(config.ArtifactoryURL)
 	if err != nil {
 		b.Logger().Error("could not parse artifactory url", "url", config.ArtifactoryURL, "err", err)

--- a/path_config.go
+++ b/path_config.go
@@ -35,6 +35,11 @@ func (b *backend) pathConfig() *framework.Path {
 				Default:     false,
 				Description: "Optional. If Artifactory version >= 7.50.3, set expires_in to max_ttl and force_revocable.",
 			},
+			"force_revocable": {
+				Type:        framework.TypeBool,
+				Default:     false,
+				Description: "Optional.",
+			},
 			"bypass_artifactory_tls_verification": {
 				Type:        framework.TypeBool,
 				Default:     false,
@@ -154,6 +159,15 @@ func (b *backend) pathConfigUpdate(ctx context.Context, req *logical.Request, da
 		config.UseExpiringTokens = val.(bool)
 	}
 
+	if val, ok := data.GetOk("force_revocable"); ok {
+
+		temp := val.(bool)
+		config.ForceRevocable = &temp
+	} else {
+
+		config.ForceRevocable = nil
+	}
+
 	if val, ok := data.GetOk("bypass_artifactory_tls_verification"); ok {
 		config.BypassArtifactoryTLSVerification = val.(bool)
 	}
@@ -257,6 +271,7 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, _ *f
 		"url":                                 config.ArtifactoryURL,
 		"version":                             b.version,
 		"use_expiring_tokens":                 config.UseExpiringTokens,
+		"force_revocable":                     config.ForceRevocable,
 		"bypass_artifactory_tls_verification": config.BypassArtifactoryTLSVerification,
 		"allow_scope_override":                config.AllowScopeOverride,
 		"revoke_on_delete":                    config.RevokeOnDelete,

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -43,6 +43,10 @@ func (e *accTestEnv) PathConfigUpdateExpiringTokens(t *testing.T) {
 	e.pathConfigUpdateBooleanField(t, "use_expiring_tokens")
 }
 
+func (e *accTestEnv) PathConfigForceRevocableTokens(t *testing.T) {
+	e.pathConfigUpdateBooleanField(t, "force_revocable")
+}
+
 func (e *accTestEnv) PathConfigUpdateBypassArtifactoryTLSVerification(t *testing.T) {
 	e.pathConfigUpdateBooleanField(t, "bypass_artifactory_tls_verification")
 }

--- a/path_config_user_token.go
+++ b/path_config_user_token.go
@@ -48,6 +48,11 @@ func (b *backend) pathConfigUserToken() *framework.Path {
 				Default:     false,
 				Description: "Optional. If Artifactory version >= 7.50.3, set expires_in to max_ttl and force_revocable.",
 			},
+			"force_revocable": {
+				Type:        framework.TypeBool,
+				Default:     false,
+				Description: "Optional.",
+			},
 			"default_ttl": {
 				Type:        framework.TypeDurationSecond,
 				Description: `Optional. Default TTL for issued user access tokens. If unset, uses the backend's default_ttl. Cannot exceed max_ttl.`,
@@ -208,6 +213,13 @@ func (b *backend) pathConfigUserTokenUpdate(ctx context.Context, req *logical.Re
 		userTokenConfig.UseExpiringTokens = adminConfig.UseExpiringTokens
 	}
 
+	if val, ok := data.GetOk("force_revocable"); ok {
+		b := val.(bool)
+		userTokenConfig.ForceRevocable = &b
+	} else {
+		userTokenConfig.ForceRevocable = adminConfig.ForceRevocable
+	}
+
 	if val, ok := data.GetOk("default_ttl"); ok {
 		userTokenConfig.DefaultTTL = time.Duration(val.(int)) * time.Second
 	}
@@ -263,6 +275,7 @@ func (b *backend) pathConfigUserTokenRead(ctx context.Context, req *logical.Requ
 		"refreshable":             userTokenConfig.Refreshable,
 		"include_reference_token": userTokenConfig.IncludeReferenceToken,
 		"use_expiring_tokens":     userTokenConfig.UseExpiringTokens,
+		"force_revocable":         userTokenConfig.ForceRevocable,
 		"default_ttl":             userTokenConfig.DefaultTTL.Seconds(),
 		"max_ttl":                 userTokenConfig.MaxTTL.Seconds(),
 		"default_description":     userTokenConfig.DefaultDescription,

--- a/path_config_user_token_test.go
+++ b/path_config_user_token_test.go
@@ -21,6 +21,7 @@ func TestAcceptanceBackend_PathConfigUserToken(t *testing.T) {
 	t.Run("update use_expiring_tokens", accTestEnv.PathConfigUseExpiringTokensUpdate)
 	t.Run("update default_ttl", accTestEnv.PathConfigDefaultTTLUpdate)
 	t.Run("update max_ttl", accTestEnv.PathConfigMaxTTLUpdate)
+	t.Run("update force_revocable", accTestEnv.PathConfigForceRevocableTokens)
 }
 
 func (e *accTestEnv) PathConfigAccessTokenUpdate(t *testing.T) {
@@ -56,6 +57,10 @@ func (e *accTestEnv) PathConfigIncludeReferenceTokenUpdate(t *testing.T) {
 
 func (e *accTestEnv) PathConfigUseExpiringTokensUpdate(t *testing.T) {
 	e.pathConfigUserTokenUpdateBoolField(t, "use_expiring_tokens")
+}
+
+func (e *accTestEnv) PathConfigForceRevocableUpdate(t *testing.T) {
+	e.pathConfigUserTokenUpdateBoolField(t, "force_revocable")
 }
 
 func (e *accTestEnv) PathConfigDefaultTTLUpdate(t *testing.T) {

--- a/path_user_token_create.go
+++ b/path_user_token_create.go
@@ -39,6 +39,11 @@ func (b *backend) pathUserTokenCreate() *framework.Path {
 				Default:     false,
 				Description: "Optional. If Artifactory version >= 7.50.3, set expires_in to max_ttl and force_revocable.",
 			},
+			"force_revocable": {
+				Type:        framework.TypeBool,
+				Default:     false,
+				Description: "Optional.",
+			},
 			"max_ttl": {
 				Type:        framework.TypeDurationSecond,
 				Description: `Optional. Override the maximum TTL for this access token. Cannot exceed smallest (system, mount, backend) maximum TTL.`,
@@ -91,6 +96,10 @@ func (b *backend) pathUserTokenCreatePerform(ctx context.Context, req *logical.R
 	baseConfig.UseExpiringTokens = userTokenConfig.UseExpiringTokens
 	if value, ok := data.GetOk("use_expiring_tokens"); ok {
 		baseConfig.UseExpiringTokens = value.(bool)
+	}
+	if value, ok := data.GetOk("force_revocable"); ok {
+		temp := value.(bool)
+		baseConfig.ForceRevocable = &temp
 	}
 
 	role := artifactoryRole{


### PR DESCRIPTION
Hello.  I went ahead and added the `force_revocable` parameter as an optional parameter.  By default, `use_expiring_tokens` will still set `force_revocable` to `true`, unless it is explicitly given.  This should solve my issue at #174.  My access tokens metadata indicated they were not revocable, but also had a value in `expires_in`.

"I have read the CLA Document and I hereby sign the CLA"