### PR TITLE
Make 'access_token' optional for 'config/admin' path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-* Make `access_token` field to `config/admin` optional for path. This allows the plugin to be configured without requiring a admin access token even if the plugin is used only to generate user token using identity token with `config/user_token` path. PR: [#189](https://github.com/jfrog/artifactory-secrets-plugin/pull/189)
+* Make `access_token` field to `config/admin` optional for path. This allows the plugin to be configured without requiring an admin access token even if the plugin is used only to generate user token using identity token with `config/user_token` path. PR: [#189](https://github.com/jfrog/artifactory-secrets-plugin/pull/189)
 
 ## 1.6.0 (April 19, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
-## 1.6.0 (April 19, 2023)
+## 1.7.0 (May 29, 2024)
+
+IMPROVEMENTS:
+
+* Make `access_token` field to `config/admin` optional for path. This allows the plugin to be configured without requiring a admin access token even if the plugin is used only to generate user token using identity token with `config/user_token` path. PR: [#189](https://github.com/jfrog/artifactory-secrets-plugin/pull/189)
+
+## 1.6.0 (April 19, 2024)
 
 IMPROVEMENTS:
 
 * Add `force_revocable` field to `config/admin`, `config/user_token`, and `config/user_token/<username>` paths. Issue: [#174](https://github.com/jfrog/artifactory-secrets-plugin/issues/174) PR: [#147](https://github.com/jfrog/artifactory-secrets-plugin/pull/147), [#175](https://github.com/jfrog/artifactory-secrets-plugin/pull/175)
 
-## 1.5.0 (March 13, 2023)
+## 1.5.0 (March 13, 2024)
 
 IMPROVEMENTS:
 
 * Add `allow_scope_override` field to `config/admin` path. This allows override of `scope` field when generating new admin scope token using `artifactory/roles/<name>` path. Issue: [#134](https://github.com/jfrog/artifactory-secrets-plugin/issues/134) PR: [#147](https://github.com/jfrog/artifactory-secrets-plugin/pull/147), [#163](https://github.com/jfrog/artifactory-secrets-plugin/pull/163)
 
-## 1.4.0 (March 11, 2023)
+## 1.4.0 (March 11, 2024)
 
 IMPROVEMENTS:
 
@@ -20,7 +26,7 @@ BUG FIXES:
 
 * Fix `default_ttl` and `max_ttl` for `config/user_token` path fall back logic. Issue: [#159](https://github.com/jfrog/artifactory-secrets-plugin/issues/159) PR: [#162](https://github.com/jfrog/artifactory-secrets-plugin/pull/162)
 
-## 1.3.0 (Feburary 27, 2023)
+## 1.3.0 (Feburary 27, 2024)
 
 IMPROVEMENTS:
 
@@ -37,7 +43,7 @@ BUG FIXES:
 
 PR: [155](https://github.com/jfrog/vault-plugin-secrets-artifactory/pull/155)
 
-## 1.2.0 (January 10, 2023)
+## 1.2.0 (January 10, 2024)
 
 IMPROVEMENTS:
 

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ No renewals or new tokens will be issued if the backend configuration (config/ad
 #### Parameters
 
 * `url` (string) - Address of the Artifactory instance, e.g. https://my.jfrog.io
-* `access_token` (stirng) - Administrator token to access Artifactory
+* `access_token` (string) - Optional. Administrator token to access Artifactory
 * `username_template` (string) - Optional. Vault Username Template for dynamically generating usernames.
 * `use_expiring_tokens` (boolean) - Optional. If Artifactory version >= 7.50.3, set `expires_in` to `max_ttl` (admin token) or `ttl` (user token) and `force_revocable = true`. Default to `false`.
 * `force_revocable` (boolean) - Optional. When set to true, we will add the `force_revocable` flag to the token's extension. In addition, a new configuration has been added that sets the default for setting the `force_revocable` default when creating a new token - the default of this configuration will be `false` to ensure that the Circle of Trust remains in place.
@@ -509,7 +509,7 @@ Configures default values for the `user_token/:user-name` path. The optional `us
 
 #### Parameters
 
-* `access_token` (stirng) - Optional. User identity token to access Artifactory. If `username` is not set then this token will be used for *all* users.
+* `access_token` (string) - Optional. User identity token to access Artifactory. If `username` is not set then this token will be used for *all* users.
 * `refresh_token` (string) - Optional. Refresh token for the user access token. If `username` is not set then this token will be used for *all* users.
 * `audience` (string) - Optional. See the JFrog Platform REST documentation on [Create Token](https://jfrog.com/help/r/jfrog-rest-apis/create-token) for a full and up to date description. Service ID must begin with valid JFrog service type. Options: jfrt, jfxr, jfpip, jfds, jfmc, jfac, jfevt, jfmd, jfcon, or *. For instructions to retrieve the Artifactory Service ID see this [documentation](https://jfrog.com/help/r/jfrog-rest-apis/get-service-id)
 * `refreshable` (boolean) - Optional. A refreshable access token gets replaced by a new access token, which is not what a consumer of tokens from this backend would be expecting; instead they'd likely just request a new token periodically. Set this to `true` only if your usage requires this. See the JFrog Platform documentation on [Generating Refreshable Tokens](https://jfrog.com/help/r/jfrog-platform-administration-documentation/generating-refreshable-tokens) for a full and up to date description. Defaults to `false`.
@@ -552,7 +552,7 @@ vault delete artifactory/config/user_token/myuser
 
 #### Parameters
 
-* `grant_type` (stirng) - Optional. Defaults to `client_credentials` when creating the access token. You likely don't need to change this.
+* `grant_type` (string) - Optional. Defaults to `client_credentials` when creating the access token. You likely don't need to change this.
 * `username` (string) - Optional. Defaults to using the username_template. The static username for which the access token is created. If the user does not exist, Artifactory will create a transient user. Note that non-administrative access tokens can only create tokens for themselves.
 * `scope` (string) - Space-delimited list. See the JFrog Artifactory REST documentation on ["Create Token"](https://jfrog.com/help/r/jfrog-rest-apis/create-token) for a full and up to date description.
 * `refreshable` (boolean) - Optional. A refreshable access token gets replaced by a new access token, which is not what a consumer of tokens from this backend would be expecting; instead they'd likely just request a new token periodically. Set this to `true` only if your usage requires this. See the JFrog Platform documentation on [Generating Refreshable Tokens](https://jfrog.com/help/r/jfrog-platform-administration-documentation/generating-refreshable-tokens) for a full and up to date description. Defaults to `false`.

--- a/backend.go
+++ b/backend.go
@@ -22,7 +22,6 @@ type backend struct {
 	rolesMutex       sync.RWMutex
 	httpClient       *http.Client
 	usernameProducer template.StringTemplate
-	version          string
 }
 
 // UsernameMetadata defines the metadata that a user_template can use to dynamically create user account in Artifactory
@@ -95,11 +94,6 @@ func (b *backend) initialize(ctx context.Context, req *logical.InitializationReq
 	}
 
 	b.InitializeHttpClient(config)
-
-	err = b.getVersion(config.baseConfiguration)
-	if err != nil {
-		return err
-	}
 
 	if len(config.UsernameTemplate) != 0 {
 		up, err := testUsernameTemplate(config.UsernameTemplate)

--- a/path_config.go
+++ b/path_config.go
@@ -18,7 +18,6 @@ func (b *backend) pathConfig() *framework.Path {
 		Fields: map[string]*framework.FieldSchema{
 			"access_token": {
 				Type:        framework.TypeString,
-				Required:    true,
 				Description: "Administrator token to access Artifactory",
 			},
 			"url": {

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -84,7 +84,7 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 
 	// Set new token and set revoke_on_delete to true
 	config.AccessToken = resp.AccessToken
-	b.Logger().Info("set config.RevokeOnDelete to 'true'")
+	b.Logger().With("func", "pathConfigRotateWrite").Info("set config.RevokeOnDelete to 'true'")
 	config.RevokeOnDelete = true
 
 	// Save new config

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -42,6 +43,10 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 
 	if config == nil {
 		return logical.ErrorResponse("backend not configured"), nil
+	}
+
+	if config.AccessToken == "" {
+		return logical.ErrorResponse("missing access token"), errors.New("missing access token")
 	}
 
 	go b.sendUsage(config.baseConfiguration, "pathConfigRotateWrite")

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -28,6 +28,7 @@ func TestAcceptanceBackend_PathRotate(t *testing.T) {
 	e.Cleanup(t)
 
 	// Failure Tests
+	t.Run("MissingAccessTokenErr", e.PathConfigRotateMissingAccessTokenErr)
 	t.Run("CreateTokenErr", e.PathConfigRotateCreateTokenErr)
 	t.Run("badAccessToken", e.PathConfigRotateBadAccessToken)
 }
@@ -65,6 +66,17 @@ func (e *accTestEnv) PathConfigRotateWithDetails(t *testing.T) {
 	assert.NotEqual(t, before["access_token_sha256sum"], after["access_token_sha256"])
 	assert.Equal(t, newUsername, after["username"])
 	// Not testing Description, because it is not returned in the token (yet)
+}
+
+func (e *accTestEnv) PathConfigRotateMissingAccessTokenErr(t *testing.T) {
+	e.UpdateConfigAdmin(t, testData{
+		"access_token": "",
+		"url":          e.URL,
+	})
+	resp, err := e.update("config/rotate", testData{})
+	assert.NotNil(t, resp)
+	assert.Contains(t, resp.Data["error"], "missing access token")
+	assert.ErrorContains(t, err, "missing access token")
 }
 
 func (e *accTestEnv) PathConfigRotateCreateTokenErr(t *testing.T) {

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -92,7 +92,6 @@ func (e *accTestEnv) PathConfigRotateBadAccessToken(t *testing.T) {
 	err = e.Storage.Put(e.Context, entry)
 	assert.NoError(t, err)
 	resp, err := e.update("config/rotate", testData{})
-	// assert.Contains(t, resp.Data["error"], "error parsing existing AccessToken")
-	assert.Contains(t, resp.Data["error"], "could not get the certificate")
+	assert.Contains(t, resp.Data["error"], "error parsing existing access token")
 	assert.Error(t, err)
 }

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -146,31 +146,14 @@ func (e *accTestEnv) PathConfigUpdateUsernameTemplate(t *testing.T) {
 
 // most of these were covered by unit tests, but we want test coverage for acceptance
 func (e *accTestEnv) PathConfigUpdateErrors(t *testing.T) {
-	// Access Token Required
-	resp, err := e.update(configAdminPath, testData{
-		"url": e.URL,
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.True(t, resp.IsError())
-	assert.Contains(t, resp.Error().Error(), "access_token")
 	// URL Required
-	resp, err = e.update(configAdminPath, testData{
+	resp, err := e.update(configAdminPath, testData{
 		"access_token": "test-access-token",
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.True(t, resp.IsError())
 	assert.Contains(t, resp.Error().Error(), "url")
-	// Bad Token
-	resp, err = e.update(configAdminPath, testData{
-		"access_token": "test-access-token",
-		"url":          e.URL,
-	})
-	assert.NotNil(t, resp)
-	assert.True(t, resp.IsError())
-	assert.Contains(t, resp.Error().Error(), "Unable to get Artifactory Version")
-	assert.ErrorContains(t, err, "could not get the system version")
 }
 
 func (e *accTestEnv) PathConfigReadBadAccessToken(t *testing.T) {

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -174,26 +174,6 @@ func (e *accTestEnv) PathConfigReadBadAccessToken(t *testing.T) {
 	// Otherwise success, we don't need to re-test for this
 }
 
-func TestBackend_AccessTokenRequired(t *testing.T) {
-	b, config := makeBackend(t)
-
-	adminConfig := map[string]interface{}{
-		"url": "https://127.0.0.1",
-	}
-
-	resp, err := b.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      configAdminPath,
-		Storage:   config.StorageView,
-		Data:      adminConfig,
-	})
-	assert.NoError(t, err)
-
-	assert.NotNil(t, resp)
-	assert.True(t, resp.IsError())
-	assert.Contains(t, resp.Error().Error(), "access_token")
-}
-
 func TestBackend_URLRequired(t *testing.T) {
 	b, config := makeBackend(t)
 

--- a/path_config_user_token.go
+++ b/path_config_user_token.go
@@ -107,8 +107,10 @@ func (b *backend) fetchUserTokenConfiguration(ctx context.Context, storage logic
 		return nil, err
 	}
 
+	logger := b.Logger().With("func", "fetchUserTokenConfiguration")
+
 	if entry == nil && len(username) > 0 {
-		b.Logger().Info(fmt.Sprintf("no configuration for username %s. Fetching default user token configuration", username), "path", configUserTokenPath)
+		logger.Info(fmt.Sprintf("no configuration for username %s. Fetching default user token configuration", username), "path", configUserTokenPath)
 		e, err := storage.Get(ctx, configUserTokenPath)
 		if err != nil {
 			return nil, err
@@ -120,7 +122,7 @@ func (b *backend) fetchUserTokenConfiguration(ctx context.Context, storage logic
 	}
 
 	if entry == nil {
-		b.Logger().Warn("no configuration found. Using system default configuration.")
+		logger.Warn("no configuration found. Using system default configuration.")
 		return &userTokenConfiguration{
 			DefaultTTL: b.Backend.System().DefaultLeaseTTL(),
 			MaxTTL:     b.Backend.System().MaxLeaseTTL(),
@@ -147,7 +149,7 @@ func (b *backend) storeUserTokenConfiguration(ctx context.Context, req *logical.
 		return err
 	}
 
-	b.Logger().Info("saving user token configuration", "path", path)
+	b.Logger().With("func", "storeUserTokenConfiguration").Info("saving user token configuration", "path", path)
 	err = req.Storage.Put(ctx, entry)
 	if err != nil {
 		return err
@@ -284,7 +286,7 @@ func (b *backend) pathConfigUserTokenRead(ctx context.Context, req *logical.Requ
 	// Optionally include token info if it parses properly
 	token, err := b.getTokenInfo(adminConfig.baseConfiguration, userTokenConfig.AccessToken)
 	if err != nil {
-		b.Logger().Warn("Error parsing AccessToken", "err", err.Error())
+		b.Logger().With("func", "pathConfigUserTokenRead").Warn("Error parsing AccessToken", "err", err.Error())
 	} else {
 		configMap["token_id"] = token.TokenID
 		configMap["username"] = token.Username

--- a/path_token_create.go
+++ b/path_token_create.go
@@ -102,11 +102,13 @@ func (b *backend) pathTokenCreatePerform(ctx context.Context, req *logical.Reque
 		}
 	}
 
+	logger := b.Logger().With("func", "pathTokenCreatePerform")
+
 	maxLeaseTTL := b.Backend.System().MaxLeaseTTL()
-	b.Logger().Debug("initialize maxLeaseTTL to system value", "maxLeaseTTL", maxLeaseTTL)
+	logger.Debug("initialize maxLeaseTTL to system value", "maxLeaseTTL", maxLeaseTTL)
 
 	if value, ok := data.GetOk("max_ttl"); ok && value.(int) > 0 {
-		b.Logger().Debug("max_ttl is set", "max_ttl", value)
+		logger.Debug("max_ttl is set", "max_ttl", value)
 		maxTTL := time.Second * time.Duration(value.(int))
 
 		// use override max TTL if set and less than maxLeaseTTL
@@ -114,26 +116,26 @@ func (b *backend) pathTokenCreatePerform(ctx context.Context, req *logical.Reque
 			maxLeaseTTL = maxTTL
 		}
 	} else if role.MaxTTL > 0 && role.MaxTTL < maxLeaseTTL {
-		b.Logger().Debug("using role MaxTTL", "role.MaxTTL", role.MaxTTL)
+		logger.Debug("using role MaxTTL", "role.MaxTTL", role.MaxTTL)
 		maxLeaseTTL = role.MaxTTL
 	}
-	b.Logger().Debug("Max lease TTL (sec)", "maxLeaseTTL", maxLeaseTTL)
+	logger.Debug("Max lease TTL (sec)", "maxLeaseTTL", maxLeaseTTL)
 
 	ttl := b.Backend.System().DefaultLeaseTTL()
 	if value, ok := data.GetOk("ttl"); ok && value.(int) > 0 {
-		b.Logger().Debug("ttl is set", "ttl", value)
+		logger.Debug("ttl is set", "ttl", value)
 		ttl = time.Second * time.Duration(value.(int))
 	} else if role.DefaultTTL != 0 {
-		b.Logger().Debug("using role DefaultTTL", "role.DefaultTTL", role.DefaultTTL)
+		logger.Debug("using role DefaultTTL", "role.DefaultTTL", role.DefaultTTL)
 		ttl = role.DefaultTTL
 	}
 
 	// cap ttl to maxLeaseTTL
 	if ttl > maxLeaseTTL {
-		b.Logger().Debug("ttl is longer than maxLeaseTTL", "ttl", ttl, "maxLeaseTTL", maxLeaseTTL)
+		logger.Debug("ttl is longer than maxLeaseTTL", "ttl", ttl, "maxLeaseTTL", maxLeaseTTL)
 		ttl = maxLeaseTTL
 	}
-	b.Logger().Debug("TTL (sec)", "ttl", ttl)
+	logger.Debug("TTL (sec)", "ttl", ttl)
 
 	// Set the role.ExpiresIn based on maxLeaseTTL if use_expiring_tokens is set to tru in config
 	// - This value will be passed to createToken and used as expires_in for versions of Artifactory 7.50.3 or higher

--- a/path_token_create.go
+++ b/path_token_create.go
@@ -77,6 +77,10 @@ func (b *backend) pathTokenCreatePerform(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
+	if config.AccessToken == "" {
+		return logical.ErrorResponse("missing access token"), errors.New("missing access token")
+	}
+
 	go b.sendUsage(config.baseConfiguration, "pathTokenCreatePerform")
 
 	// Read in the requested role

--- a/path_token_create_test.go
+++ b/path_token_create_test.go
@@ -40,3 +40,22 @@ func TestAcceptanceBackend_PathTokenCreate_overrides(t *testing.T) {
 	t.Run("delete role", accTestEnv.DeletePathRole)
 	t.Run("cleanup backend", accTestEnv.DeletePathConfig)
 }
+
+func TestAcceptanceBackend_PathTokenCreate_no_access_token(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	accTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accTestEnv.AccessToken = ""
+
+	t.Run("configure backend with no access token", accTestEnv.UpdatePathConfig)
+	t.Run("create role", accTestEnv.CreatePathRole)
+	t.Run("create token for role", accTestEnv.CreatePathToken_no_access_token)
+	t.Run("delete role", accTestEnv.DeletePathRole)
+	t.Run("cleanup backend", accTestEnv.DeletePathConfig)
+}

--- a/path_user_token_create.go
+++ b/path_user_token_create.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -91,6 +92,10 @@ func (b *backend) pathUserTokenCreatePerform(ctx context.Context, req *logical.R
 
 	if userTokenConfig.baseConfiguration.AccessToken != "" {
 		baseConfig.AccessToken = userTokenConfig.baseConfiguration.AccessToken
+	}
+
+	if baseConfig.AccessToken == "" {
+		return logical.ErrorResponse("missing access token"), errors.New("missing access token")
 	}
 
 	baseConfig.UseExpiringTokens = userTokenConfig.UseExpiringTokens

--- a/path_user_token_create_test.go
+++ b/path_user_token_create_test.go
@@ -33,3 +33,20 @@ func TestAcceptanceBackend_PathUserTokenCreate_overrides(t *testing.T) {
 	t.Run("create token for admin user", accTestEnv.CreatePathUserToken_overrides)
 	t.Run("cleanup backend", accTestEnv.DeletePathConfig)
 }
+
+func TestAcceptanceBackend_PathUserTokenCreate_no_access_token(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	accTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accTestEnv.AccessToken = ""
+
+	t.Run("configure backend with no access token", accTestEnv.UpdatePathConfig)
+	t.Run("create token for admin user", accTestEnv.CreatePathUserToken_no_access_token)
+	t.Run("cleanup backend", accTestEnv.DeletePathConfig)
+}

--- a/test_utils.go
+++ b/test_utils.go
@@ -310,6 +310,19 @@ func (e *accTestEnv) CreatePathToken_overrides(t *testing.T) {
 	assert.Equal(t, 60, resp.Data["expires_in"])
 }
 
+func (e *accTestEnv) CreatePathToken_no_access_token(t *testing.T) {
+	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "token/admin-role",
+		Storage:   e.Storage,
+	})
+
+	assert.Error(t, err, "missing access token")
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Data["access_token"])
+	assert.Empty(t, resp.Data["token_id"])
+}
+
 func (e *accTestEnv) CreatePathScopedDownToken(t *testing.T) {
 	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
@@ -419,6 +432,35 @@ func (e *accTestEnv) CreatePathUserToken_overrides(t *testing.T) {
 	assert.Equal(t, 600, resp.Data["expires_in"])
 	assert.NotEmpty(t, resp.Data["refresh_token"])
 	assert.NotEmpty(t, resp.Data["reference_token"])
+}
+
+func (e *accTestEnv) CreatePathUserToken_no_access_token(t *testing.T) {
+	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      configUserTokenPath + "/admin",
+		Storage:   e.Storage,
+		Data: map[string]interface{}{
+			"default_description":     "foo",
+			"refreshable":             true,
+			"include_reference_token": true,
+			"use_expiring_tokens":     true,
+			"default_ttl":             60,
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+
+	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      createUserTokenPath + "admin",
+		Storage:   e.Storage,
+	})
+
+	assert.Error(t, err, "missing access token")
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Data["access_token"])
+	assert.Empty(t, resp.Data["token_id"])
 }
 
 // Cleanup will delete the admin configuration and revoke the token

--- a/test_utils.go
+++ b/test_utils.go
@@ -49,11 +49,6 @@ func (e *accTestEnv) createNewTestToken(t *testing.T) (string, string) {
 
 	e.Backend.(*backend).InitializeHttpClient(&config)
 
-	err := e.Backend.(*backend).getVersion(config.baseConfiguration)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	resp, err := e.Backend.(*backend).CreateToken(config.baseConfiguration, role)
 	if err != nil {
 		t.Fatal(err)
@@ -80,11 +75,6 @@ func (e *accTestEnv) createNewNonAdminTestToken(t *testing.T) (string, string) {
 
 	e.Backend.(*backend).InitializeHttpClient(&config)
 
-	err := e.Backend.(*backend).getVersion(config.baseConfiguration)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	resp, err := e.Backend.(*backend).CreateToken(config.baseConfiguration, role)
 	if err != nil {
 		t.Fatal(err)
@@ -99,12 +89,7 @@ func (e *accTestEnv) revokeTestToken(t *testing.T, accessToken string, tokenID s
 		ArtifactoryURL: e.URL,
 	}
 
-	err := e.Backend.(*backend).getVersion(config)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = e.Backend.(*backend).RevokeToken(config, tokenID, accessToken)
+	err := e.Backend.(*backend).RevokeToken(config, tokenID, accessToken)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This allows the plugin to be configured without requiring a admin access token even if the plugin is used only to generate user token using identity token with `config/user_token` path.