### PR TITLE
Fix user token refresh not working after token expired

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Install Helm
         uses: azure/setup-helm@v4.2.0
       - name: Install GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.22
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
         goarch: '386'
     binary: artifactory-secrets-plugin
 snapshot:
-  name_template: '{{ .Version }}'
+  version_template: '{{ .Version }}'
 archives:
   - format: binary
 checksum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.1 (November 8, 2024)
+## 1.8.1 (November 8, 2024). Tested on Artifactory 7.98.8 with Vault v1.18.1 and OpenBao v2.0.0
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.1 (November 8, 2024)
+
+BUG FIXES:
+
+* Fix error when reading `config/user_token` with expired access token and failed to refresh. Issue: [#217](https://github.com/jfrog/artifactory-secrets-plugin/issues/217) PR: [#223](https://github.com/jfrog/artifactory-secrets-plugin/pull/223)
+
 ## 1.8.0 (June 7, 2024)
 
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/jfrog/vault-plugin-secrets-artifactory
 
-go 1.21
-toolchain go1.22.5
+go 1.22
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -104,7 +104,7 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 	}
 
 	// Invalidate Old Token
-	err = b.RevokeToken(config.baseConfiguration, token.TokenID, oldAccessToken)
+	err = b.RevokeToken(config.baseConfiguration, token.TokenID)
 	if err != nil {
 		return logical.ErrorResponse("error revoking existing access token %s", token.TokenID), err
 	}

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -89,7 +89,7 @@ func (e *accTestEnv) PathConfigRotateCreateTokenErr(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Contains(t, resp.Data["error"], "error creating new access token")
 	assert.ErrorContains(t, err, "could not create access token")
-	e.revokeTestToken(t, e.AccessToken, tokenId)
+	e.revokeTestToken(t, tokenId)
 }
 
 func (e *accTestEnv) PathConfigRotateBadAccessToken(t *testing.T) {

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -169,8 +169,8 @@ func (e *accTestEnv) PathConfigReadBadAccessToken(t *testing.T) {
 	assert.NoError(t, err)
 	resp, err := e.read(configAdminPath)
 
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
 	// Otherwise success, we don't need to re-test for this
 }
 

--- a/path_config_user_token_test.go
+++ b/path_config_user_token_test.go
@@ -25,15 +25,18 @@ func TestAcceptanceBackend_PathConfigUserToken(t *testing.T) {
 }
 
 func (e *accTestEnv) PathConfigAccessTokenUpdate(t *testing.T) {
+	_, accessToken1 := e.createNewTestToken(t)
+
 	e.UpdateConfigUserToken(t, "", testData{
-		"access_token": "test123",
+		"access_token": accessToken1,
 	})
 	data := e.ReadConfigUserToken(t, "")
 	accessTokenHash := data["access_token_sha256"]
 	assert.NotEmpty(t, "access_token_sha256")
 
+	_, accessToken2 := e.createNewTestToken(t)
 	e.UpdateConfigUserToken(t, "", testData{
-		"access_token": "test456",
+		"access_token": accessToken2,
 	})
 	data = e.ReadConfigUserToken(t, "")
 	assert.NotEqual(t, data["access_token_sha256"], accessTokenHash)
@@ -138,6 +141,11 @@ func TestAcceptanceBackend_PathConfigUserToken_UseSystemDefault(t *testing.T) {
 		t.SkipNow()
 	}
 	accTestEnv := NewConfiguredAcceptanceTestEnv(t)
+
+	_, accessToken1 := accTestEnv.createNewTestToken(t)
+	accTestEnv.UpdateConfigUserToken(t, "", testData{
+		"access_token": accessToken1,
+	})
 
 	data := accTestEnv.ReadConfigUserToken(t, "")
 	assert.Equal(t, accTestEnv.Backend.System().DefaultLeaseTTL().Seconds(), data["default_ttl"])

--- a/secret_access_token.go
+++ b/secret_access_token.go
@@ -85,8 +85,7 @@ func (b *backend) secretAccessTokenRevoke(ctx context.Context, req *logical.Requ
 	}
 
 	tokenId := req.Secret.InternalData["token_id"].(string)
-	accessToken := req.Secret.InternalData["access_token"].(string)
-	if err := b.RevokeToken(config.baseConfiguration, tokenId, accessToken); err != nil {
+	if err := b.RevokeToken(config.baseConfiguration, tokenId); err != nil {
 		return nil, err
 	}
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -36,8 +36,9 @@ type testData map[string]interface{}
 func (e *accTestEnv) createNewTestToken(t *testing.T) (string, string) {
 	config := adminConfiguration{
 		baseConfiguration: baseConfiguration{
-			AccessToken:    e.AccessToken,
-			ArtifactoryURL: e.URL,
+			AccessToken:     e.AccessToken,
+			ArtifactoryURL:  e.URL,
+			UseNewAccessAPI: true,
 		},
 	}
 
@@ -62,8 +63,9 @@ func (e *accTestEnv) createNewTestToken(t *testing.T) (string, string) {
 func (e *accTestEnv) createNewNonAdminTestToken(t *testing.T) (string, string) {
 	config := adminConfiguration{
 		baseConfiguration: baseConfiguration{
-			AccessToken:    e.AccessToken,
-			ArtifactoryURL: e.URL,
+			AccessToken:     e.AccessToken,
+			ArtifactoryURL:  e.URL,
+			UseNewAccessAPI: true,
 		},
 	}
 
@@ -83,13 +85,13 @@ func (e *accTestEnv) createNewNonAdminTestToken(t *testing.T) (string, string) {
 	return resp.TokenId, resp.AccessToken
 }
 
-func (e *accTestEnv) revokeTestToken(t *testing.T, accessToken string, tokenID string) {
+func (e *accTestEnv) revokeTestToken(t *testing.T, tokenID string) {
 	config := baseConfiguration{
 		AccessToken:    e.AccessToken,
 		ArtifactoryURL: e.URL,
 	}
 
-	err := e.Backend.(*backend).RevokeToken(config, tokenID, accessToken)
+	err := e.Backend.(*backend).RevokeToken(config, tokenID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +507,7 @@ func (e *accTestEnv) Cleanup(t *testing.T) {
 	e.DeleteConfigAdmin(t)
 
 	// revoke the test token
-	e.revokeTestToken(t, e.AccessToken, data["token_id"].(string))
+	e.revokeTestToken(t, data["token_id"].(string))
 }
 
 func newAcceptanceTestEnv() (*accTestEnv, error) {

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -218,7 +218,7 @@ func TestBackend_UserTokenConfigMaxTTLUseConfigMaxTTL(t *testing.T) {
 
 	configPath := configUserTokenPath + "/admin"
 	backend_max_ttl := b.System().MaxLeaseTTL()
-	user_token_config_ttl := backend_max_ttl - 1*time.Minute
+	user_token_config_ttl := backend_max_ttl - 10*time.Minute
 	SetUserTokenMaxTTL(t, b, config.StorageView, configPath, user_token_config_ttl)
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{


### PR DESCRIPTION
Fixes #217 

* Upgrade to Go 1.22
* Update GoReleaser config for deprecated key
* Handle expired access token when reading user config and attempt to refresh the token
* Split off code for refreshing token from create token.
* Move code that determine whether to use new or old API to earlier when config is being created. The value is then stored in the config for later use.
* Use token ID only when revoking token
* More logging with func context