### PR TITLE
Switched to use Access API for checking expired token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.4 (December 9, 2024). Tested on Artifactory 7.98.9 with Vault v1.18.2 and OpenBao v2.0.0
+## 1.8.4 (December 9, 2024). Tested on Artifactory 7.98.10 with Vault v1.18.2 and OpenBao v2.0.0
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.8.4 (December 9, 2024)
+## 1.8.4 (December 9, 2024). Tested on Artifactory 7.98.9 with Vault v1.18.2 and OpenBao v2.0.0
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.4 (December 9, 2024)
+
+BUG FIXES:
+
+* Fix error when refreshing expired user token. Issue: [#225](https://github.com/jfrog/artifactory-secrets-plugin/issues/225) PR: [#230](https://github.com/jfrog/artifactory-secrets-plugin/pull/230)
+
 ## 1.8.3 (November 22, 2024)
 
 NOTES:

--- a/backend.go
+++ b/backend.go
@@ -100,7 +100,9 @@ func (b *backend) initialize(ctx context.Context, req *logical.InitializationReq
 		if err != nil {
 			return err
 		}
+		b.configMutex.Lock()
 		b.usernameProducer = up
+		b.configMutex.Unlock()
 	}
 
 	return nil

--- a/path_config_user_token.go
+++ b/path_config_user_token.go
@@ -94,9 +94,6 @@ type userTokenConfiguration struct {
 }
 
 func (c *userTokenConfiguration) RefreshAccessToken(ctx context.Context, req *logical.Request, username string, b *backend, adminBaseConfig baseConfiguration) error {
-	b.configMutex.Lock()
-	defer b.configMutex.Unlock()
-
 	logger := b.Logger().With("func", "RefreshAccessToken")
 
 	if c.RefreshToken == "" {
@@ -271,8 +268,8 @@ func (b *backend) pathConfigUserTokenUpdate(ctx context.Context, req *logical.Re
 }
 
 func (b *backend) pathConfigUserTokenRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	b.configMutex.RLock()
-	defer b.configMutex.RUnlock()
+	b.configMutex.Lock()
+	defer b.configMutex.Unlock()
 
 	baseConfig := baseConfiguration{}
 

--- a/path_user_token_create.go
+++ b/path_user_token_create.go
@@ -50,7 +50,7 @@ func (b *backend) pathUserTokenCreate() *framework.Path {
 			},
 			"ttl": {
 				Type:        framework.TypeDurationSecond,
-				Description: `Optional. Override the default TTL when issuing this access token. Cappaed at the smallest maximum TTL (system, mount, backend, request).`,
+				Description: `Optional. Override the default TTL when issuing this access token. Capped at the smallest maximum TTL (system, mount, backend, request).`,
 			},
 			"scope": {
 				Type:        framework.TypeString,
@@ -68,8 +68,10 @@ func (b *backend) pathUserTokenCreate() *framework.Path {
 }
 
 func (b *backend) pathUserTokenCreatePerform(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	b.configMutex.RLock()
-	defer b.configMutex.RUnlock()
+	b.configMutex.Lock()
+	defer b.configMutex.Unlock()
+
+	logger := b.Logger().With("func", "pathUserTokenCreatePerform")
 
 	baseConfig := baseConfiguration{}
 
@@ -125,8 +127,6 @@ func (b *backend) pathUserTokenCreatePerform(ctx context.Context, req *logical.R
 		Description:           userTokenConfig.DefaultDescription,
 		RefreshToken:          userTokenConfig.RefreshToken,
 	}
-
-	logger := b.Logger().With("func", "pathUserTokenCreatePerform")
 
 	maxLeaseTTL := b.Backend.System().MaxLeaseTTL()
 	logger.Debug("initialize maxLeaseTTL to system value", "maxLeaseTTL", maxLeaseTTL)

--- a/test/concurrent_read.sh
+++ b/test/concurrent_read.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+vault read artifactory/user_token/test &
+vault read artifactory/user_token/test &
+wait

--- a/test/expired.sh
+++ b/test/expired.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+vault write artifactory/config/admin url=$JFROG_URL use_expiring_tokens=true max_ttl=14400 default_ttl=3600
+
+USER_TOKEN=$(curl -s -L "${JFROG_URL}/access/api/v1/tokens" -H 'Content-Type: application/json' -H "Authorization: Bearer ${JFROG_ACCESS_TOKEN}" --data-raw '{"grant_type":"client_credentials","username":"admin","scope":"applied-permissions/user applied-permissions/admin","refreshable":true,"audience":"*@*","expires_in":60,"force_revocable":false,"include_reference_token":false}')
+
+USER_ACCESS_TOKEN=$(echo ${USER_TOKEN} | jq -r ".access_token")
+echo "USER_ACCESS_TOKEN: ${USER_ACCESS_TOKEN}"
+
+USER_REFRESH_TOKEN=$(echo ${USER_TOKEN} | jq -r ".refresh_token")
+echo "USER_REFRESH_TOKEN: ${USER_REFRESH_TOKEN}"
+
+vault write artifactory/config/user_token access_token=${USER_ACCESS_TOKEN} refresh_token=${USER_REFRESH_TOKEN} refreshable=true use_expiring_tokens=true max_ttl=14400 default_ttl=3600
+vault read artifactory/config/user_token
+vault read artifactory/user_token/test
+
+date

--- a/test/expired.sh
+++ b/test/expired.sh
@@ -2,7 +2,12 @@
 
 vault write artifactory/config/admin url=$JFROG_URL use_expiring_tokens=true max_ttl=14400 default_ttl=3600
 
-USER_TOKEN=$(curl -s -L "${JFROG_URL}/access/api/v1/tokens" -H 'Content-Type: application/json' -H "Authorization: Bearer ${JFROG_ACCESS_TOKEN}" --data-raw '{"grant_type":"client_credentials","username":"admin","scope":"applied-permissions/user applied-permissions/admin","refreshable":true,"audience":"*@*","expires_in":60,"force_revocable":false,"include_reference_token":false}')
+# create non-admin token
+# ensure there's a non-admin user named `test` in Artifactory first
+USER_TOKEN=$(curl -s -L "${JFROG_URL}/access/api/v1/tokens" -H 'Content-Type: application/json' -H "Authorization: Bearer ${JFROG_ACCESS_TOKEN}" --data-raw '{"grant_type":"client_credentials","username":"test","scope":"applied-permissions/user","refreshable":true,"audience":"*@*","expires_in":60,"force_revocable":false,"include_reference_token":false}')
+
+# create admin token
+# USER_TOKEN=$(curl -s -L "${JFROG_URL}/access/api/v1/tokens" -H 'Content-Type: application/json' -H "Authorization: Bearer ${JFROG_ACCESS_TOKEN}" --data-raw '{"grant_type":"client_credentials","username":"admin","scope":"applied-permissions/admin","refreshable":true,"audience":"*@*","expires_in":60,"force_revocable":false,"include_reference_token":false}')
 
 USER_ACCESS_TOKEN=$(echo ${USER_TOKEN} | jq -r ".access_token")
 echo "USER_ACCESS_TOKEN: ${USER_ACCESS_TOKEN}"

--- a/test_utils.go
+++ b/test_utils.go
@@ -652,3 +652,10 @@ func mockArtifactoryUsageVersionRequests(version string) {
 		"http://myserver.com:80/artifactory/api/system/version",
 		httpmock.NewStringResponder(200, versionString))
 }
+
+func mockArtifactoryRoleRequest() {
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		"http://myserver.com:80/access/api/v1/roles/Viewer",
+		httpmock.NewStringResponder(200, ""))
+}

--- a/test_utils.go
+++ b/test_utils.go
@@ -653,9 +653,9 @@ func mockArtifactoryUsageVersionRequests(version string) {
 		httpmock.NewStringResponder(200, versionString))
 }
 
-func mockArtifactoryRoleRequest() {
+func mockArtifactoryTokenRequest() {
 	httpmock.RegisterResponder(
 		http.MethodGet,
-		"http://myserver.com:80/access/api/v1/roles/Viewer",
+		"http://myserver.com:80/access/api/v1/tokens/me",
 		httpmock.NewStringResponder(200, ""))
 }

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -122,7 +122,7 @@ func TestBackend_NoUserTokensMaxTTLUsesSystemMaxTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
-	mockArtifactoryRoleRequest()
+	mockArtifactoryTokenRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -172,7 +172,7 @@ func TestBackend_UserTokenConfigMaxTTLUseSystem(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
-	mockArtifactoryRoleRequest()
+	mockArtifactoryTokenRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -207,7 +207,7 @@ func TestBackend_UserTokenConfigMaxTTLUseConfigMaxTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
-	mockArtifactoryRoleRequest()
+	mockArtifactoryTokenRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -242,7 +242,7 @@ func TestBackend_UserTokenMaxTTLUseRequestTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
-	mockArtifactoryRoleRequest()
+	mockArtifactoryTokenRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -277,7 +277,7 @@ func TestBackend_UserTokenMaxTTLEnforced(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
-	mockArtifactoryRoleRequest()
+	mockArtifactoryTokenRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -313,7 +313,7 @@ func TestBackend_UserTokenTTLRequest(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
-	mockArtifactoryRoleRequest()
+	mockArtifactoryTokenRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -345,7 +345,7 @@ func TestBackend_UserTokenDefaultTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
-	mockArtifactoryRoleRequest()
+	mockArtifactoryTokenRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -122,6 +122,7 @@ func TestBackend_NoUserTokensMaxTTLUsesSystemMaxTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
+	mockArtifactoryRoleRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -171,6 +172,7 @@ func TestBackend_UserTokenConfigMaxTTLUseSystem(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
+	mockArtifactoryRoleRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -205,6 +207,7 @@ func TestBackend_UserTokenConfigMaxTTLUseConfigMaxTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
+	mockArtifactoryRoleRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -239,6 +242,7 @@ func TestBackend_UserTokenMaxTTLUseRequestTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
+	mockArtifactoryRoleRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -273,6 +277,7 @@ func TestBackend_UserTokenMaxTTLEnforced(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
+	mockArtifactoryRoleRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -308,6 +313,7 @@ func TestBackend_UserTokenTTLRequest(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
+	mockArtifactoryRoleRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,
@@ -339,6 +345,7 @@ func TestBackend_UserTokenDefaultTTL(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	mockArtifactoryUsageVersionRequests("")
+	mockArtifactoryRoleRequest()
 
 	httpmock.RegisterResponder(
 		http.MethodPost,


### PR DESCRIPTION
Remove mutex from RefreshAccessToken()

Switch to RW lock for pathConfigUserTokenRead() and pathUserTokenCreatePerform()

Add scripts for testing refreshable tokens creation and concurrent token generation

Fixes #225 