### PR TITLE
Allow to specify role in the scope override

### DIFF
--- a/path_token_create.go
+++ b/path_token_create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-var GroupPermissionScopeRegex = regexp.MustCompile(`^applied-permissions\/groups:.+$`)
+var PermissionScopeRegex = regexp.MustCompile(`^applied-permissions\/(groups|roles):.+$`)
 
 func (b *backend) pathTokenCreate() *framework.Path {
 	return &framework.Path{
@@ -29,8 +29,11 @@ func (b *backend) pathTokenCreate() *framework.Path {
 				Description: `Override the maximum TTL for this access token. Cannot exceed smallest (system, backend) maximum TTL.`,
 			},
 			"scope": {
-				Type:        framework.TypeString,
-				Description: `Override the scope for this access token. Limited to group scope only: 'applied-permissions/groups:<group-name>[,<group-name>...]'. Only applicable when config field 'allow_scope_override' is set to 'true'.`,
+				Type: framework.TypeString,
+				Description: `Override the scope for this access token. Limited to group or role scope only: ` +
+					`'applied-permissions/groups:<group-name>[,<group-name>...]' or ` +
+					`'applied-permissions/roles:<role-name>[,<role-name>...]'. ` +
+					`Only applicable when config field 'allow_scope_override' is set to 'true'.`,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -152,7 +155,7 @@ func (b *backend) pathTokenCreatePerform(ctx context.Context, req *logical.Reque
 	if config.AllowScopeOverride {
 		scope := data.Get("scope").(string)
 		if len(scope) != 0 {
-			match := GroupPermissionScopeRegex.MatchString(scope)
+			match := PermissionScopeRegex.MatchString(scope)
 			if !match {
 				return logical.ErrorResponse("provided scope is invalid"), errors.New("provided scope is invalid")
 			}

--- a/path_user_token_create.go
+++ b/path_user_token_create.go
@@ -53,8 +53,11 @@ func (b *backend) pathUserTokenCreate() *framework.Path {
 				Description: `Optional. Override the default TTL when issuing this access token. Capped at the smallest maximum TTL (system, mount, backend, request).`,
 			},
 			"scope": {
-				Type:        framework.TypeString,
-				Description: `Override the scope (default: 'applied-permissions/user') for this access token. Limited to group scope only: 'applied-permissions/groups:<group-name>[,<group-name>...]'.`,
+				Type: framework.TypeString,
+				Description: `Override the scope (default: 'applied-permissions/user') for this access token. ` +
+					`Limited to group or role scope only: ` +
+					`'applied-permissions/groups:<group-name>[,<group-name>...]' or ` +
+					`'applied-permissions/roles:<role-name>[,<role-name>...]'.`,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -185,7 +188,7 @@ func (b *backend) pathUserTokenCreatePerform(ctx context.Context, req *logical.R
 
 	scope := data.Get("scope").(string)
 	if len(scope) != 0 {
-		match := GroupPermissionScopeRegex.MatchString(scope)
+		match := PermissionScopeRegex.MatchString(scope)
 		if !match {
 			return logical.ErrorResponse("provided scope is invalid"), errors.New("provided scope is invalid")
 		}


### PR DESCRIPTION
This PR allows overriding the role in the scope override for the `token` endpoint. This is important to ensure consistency with the plugin role definition, which is working perfectly fine. We need this to dynamically define roles based on our logic, without creating hundreds of vault roles.