### PR TITLE
[security] Enforce allow_scope_override on user_token paths

### DIFF
--- a/path_user_token_create.go
+++ b/path_user_token_create.go
@@ -183,14 +183,16 @@ func (b *backend) pathUserTokenCreatePerform(ctx context.Context, req *logical.R
 		role.Description = value.(string)
 	}
 
-	scope := data.Get("scope").(string)
-	if len(scope) != 0 {
-		match := GroupPermissionScopeRegex.MatchString(scope)
-		if !match {
-			return logical.ErrorResponse("provided scope is invalid"), errors.New("provided scope is invalid")
+	if adminConfig.AllowScopeOverride {
+		scope := data.Get("scope").(string)
+		if len(scope) != 0 {
+			match := GroupPermissionScopeRegex.MatchString(scope)
+			if !match {
+				return logical.ErrorResponse("provided scope is invalid"), errors.New("provided scope is invalid")
+			}
+			//use the overridden scope rather than role default
+			role.Scope = scope
 		}
-		//use the overridden scope rather than role default
-		role.Scope = scope
 	}
 
 	resp, err := b.CreateToken(baseConfig, role)


### PR DESCRIPTION
The user_token/:username path accepted a caller-provided `scope` parameter unconditionally, bypassing the `allow_scope_override` admin configuration flag. The equivalent `token/:role-name` path (path_token_create.go:152) correctly gated scope override on the flag; user_token did not.

Security impact: any Vault identity with `read` on `artifactory/user_token/:username` could request an Artifactory access token scoped to arbitrary groups — e.g.
`scope=applied-permissions/groups:admin` — regardless of the plugin's `allow_scope_override` setting. Because the flag defaults to false, every installation that relied on the default to forbid scope overrides was affected, contrary to the README warning ("Enable Scoped down Tokens") which presents the flag as the switch controlling this behavior.

Fix: wrap the scope parsing and role.Scope assignment in path_user_token_create.go in an `if adminConfig.AllowScopeOverride` check, matching path_token_create.go. When the flag is false, any `scope` parameter on the request is silently ignored and the role's default scope is used.