### PR TITLE
Fix nil httpClient panic (SIGSEGV) after config invalidation on standby nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.10 (Unreleased)
+
+BUG FIXES:
+
+* Fix nil pointer dereference (SIGSEGV) in `performArtifactoryGet`, `performArtifactoryPost`, `performArtifactoryPostWithJSON`, and `performArtifactoryDelete` when the backend HTTP client is `nil` after a `config` invalidation on standby / performance-standby / replica nodes. A subsequent `config/*` read runs `go b.sendUsage(...)`, whose unrecovered goroutine dereferenced the nil client and crashed the entire plugin process (the go-plugin gRPC server), leaving a dead socket and `no such file` transport errors. The `performArtifactory*` helpers now guard against a nil client and return an error instead of panicking. Additionally, `sendUsage` (a detached, non-critical telemetry goroutine) now recovers from panics so usage reporting can never crash the plugin process. PR: [#348](https://github.com/jfrog/vault-plugin-secrets-artifactory/pull/348)
+
 ## 1.8.5 (January 14, 2025). Tested on Artifactory 7.125.7 with Vault v1.21.1 and OpenBao v2.0.0
 
 BUG FIXES:

--- a/artifactory.go
+++ b/artifactory.go
@@ -658,6 +658,16 @@ type Usage struct {
 func (b *backend) sendUsage(config baseConfiguration, featureId string) {
 	logger := b.Logger().With("func", "sendUsage")
 
+	// sendUsage is always launched as a detached goroutine (go b.sendUsage(...))
+	// for non-critical "call home" telemetry. In Go an unrecovered panic in any
+	// goroutine crashes the whole process, so contain it here: usage reporting
+	// must never be able to take down the plugin.
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("recovered from panic in usage reporting", "panic", r)
+		}
+	}()
+
 	if config.AccessToken == "" {
 		logger.Info("access token is empty in config")
 		return
@@ -698,6 +708,12 @@ func (b *backend) performArtifactoryGet(config baseConfiguration, path string) (
 		return nil, fmt.Errorf("empty access token not allowed")
 	}
 
+	client := b.httpClient.Load()
+	if client == nil {
+		logger.Error("http client is not initialized")
+		return nil, fmt.Errorf("http client not initialized (config may have been invalidated and not reloaded)")
+	}
+
 	u, err := parseURLWithDefaultPort(config.ArtifactoryURL)
 	if err != nil {
 		return nil, err
@@ -714,13 +730,18 @@ func (b *backend) performArtifactoryGet(config baseConfiguration, path string) (
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	return b.httpClient.Do(req)
+	return client.Do(req)
 }
 
 // performArtifactoryPost will HTTP POST values to the Artifactory API.
 func (b *backend) performArtifactoryPost(config baseConfiguration, path string, values url.Values) (*http.Response, error) {
 	if config.AccessToken == "" {
 		return nil, fmt.Errorf("empty access token not allowed")
+	}
+
+	client := b.httpClient.Load()
+	if client == nil {
+		return nil, fmt.Errorf("http client not initialized (config may have been invalidated and not reloaded)")
 	}
 
 	u, err := parseURLWithDefaultPort(config.ArtifactoryURL)
@@ -740,7 +761,7 @@ func (b *backend) performArtifactoryPost(config baseConfiguration, path string, 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	return b.httpClient.Do(req)
+	return client.Do(req)
 }
 
 // performArtifactoryPost will HTTP POST data to the Artifactory API.
@@ -750,6 +771,12 @@ func (b *backend) performArtifactoryPostWithJSON(config baseConfiguration, path 
 	if config.AccessToken == "" {
 		logger.Error("config.AccessToken is empty")
 		return nil, fmt.Errorf("empty access token not allowed")
+	}
+
+	client := b.httpClient.Load()
+	if client == nil {
+		logger.Error("http client is not initialized")
+		return nil, fmt.Errorf("http client not initialized (config may have been invalidated and not reloaded)")
 	}
 
 	u, err := parseURLWithDefaultPort(config.ArtifactoryURL)
@@ -770,7 +797,7 @@ func (b *backend) performArtifactoryPostWithJSON(config baseConfiguration, path 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 	req.Header.Add("Content-Type", "application/json")
 
-	return b.httpClient.Do(req)
+	return client.Do(req)
 }
 
 // performArtifactoryDelete will HTTP DELETE to the Artifactory API.
@@ -781,6 +808,12 @@ func (b *backend) performArtifactoryDelete(config baseConfiguration, path string
 	if config.AccessToken == "" {
 		logger.Error("config.AccessToken is empty")
 		return nil, fmt.Errorf("empty access token not allowed")
+	}
+
+	client := b.httpClient.Load()
+	if client == nil {
+		logger.Error("http client is not initialized")
+		return nil, fmt.Errorf("http client not initialized (config may have been invalidated and not reloaded)")
 	}
 
 	u, err := parseURLWithDefaultPort(config.ArtifactoryURL)
@@ -800,7 +833,7 @@ func (b *backend) performArtifactoryDelete(config baseConfiguration, path string
 	req.Header.Set("User-Agent", productId)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 
-	return b.httpClient.Do(req)
+	return client.Do(req)
 }
 
 func parseURLWithDefaultPort(rawUrl string) (*url.URL, error) {

--- a/artifactory_nil_httpclient_test.go
+++ b/artifactory_nil_httpclient_test.go
@@ -1,0 +1,112 @@
+package artifactory
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// TestPerformArtifactory_NilHTTPClient_ReturnsError verifies that each
+// performArtifactory* helper returns an error (instead of panicking) when the
+// backend's HTTP client is nil.
+//
+// This is the state a standby / performance-standby / replica node ends up in:
+// a change to the `config` storage key calls invalidate("config") -> reset(),
+// which sets b.httpClient = nil. The client is only (re)initialised by
+// initialize() at process start and by pathConfigUpdate() on a write, neither
+// of which runs on those nodes, so the client stays nil until the next restart.
+func TestPerformArtifactory_NilHTTPClient_ReturnsError(t *testing.T) {
+	b, _ := makeBackend(t)
+
+	// A change to the `config` key calls invalidate("config") -> reset(), which
+	// nils the HTTP client; on standby/replica nodes it is never re-initialised.
+	b.reset()
+
+	config := baseConfiguration{
+		AccessToken:    "dummy-non-empty-token",
+		ArtifactoryURL: "http://myserver.com",
+	}
+
+	t.Run("Get", func(t *testing.T) {
+		if _, err := b.performArtifactoryGet(config, "/artifactory/api/system/version"); err == nil {
+			t.Fatal("expected an error with a nil httpClient, got nil")
+		}
+	})
+	t.Run("Post", func(t *testing.T) {
+		if _, err := b.performArtifactoryPost(config, "/artifactory/api/system/ping", url.Values{}); err == nil {
+			t.Fatal("expected an error with a nil httpClient, got nil")
+		}
+	})
+	t.Run("PostWithJSON", func(t *testing.T) {
+		if _, err := b.performArtifactoryPostWithJSON(config, "/artifactory/api/system/usage", []byte("{}")); err == nil {
+			t.Fatal("expected an error with a nil httpClient, got nil")
+		}
+	})
+	t.Run("Delete", func(t *testing.T) {
+		if _, err := b.performArtifactoryDelete(config, "/access/api/v1/tokens/dummy"); err == nil {
+			t.Fatal("expected an error with a nil httpClient, got nil")
+		}
+	})
+}
+
+// TestConfigReadWithNilHTTPClient_DoesNotCrash reproduces the original crash
+// end to end. Reading config/admin fires `go b.sendUsage(...)` (see
+// path_config.go); before the fix that goroutine dereferenced the nil client
+// and, being unrecovered, crashed the whole plugin process (the go-plugin gRPC
+// server), leaving a dead unix socket and "no such file" transport errors.
+//
+// Before the fix this test aborts the test binary with a SIGSEGV; after the fix
+// the nil-guarded helpers return an error and the process survives.
+func TestConfigReadWithNilHTTPClient_DoesNotCrash(t *testing.T) {
+	ctx := context.Background()
+	b, config := makeBackend(t)
+	b.InitializeHttpClient(&adminConfiguration{}) // client set, as on an active node
+
+	// Persist an admin config so the read path has something to read, without an
+	// HTTP-triggering config update.
+	entry, err := logical.StorageEntryJSON(configAdminPath, adminConfiguration{
+		baseConfiguration: baseConfiguration{
+			AccessToken:    "dummy-non-empty-token",
+			ArtifactoryURL: "http://myserver.com",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := config.StorageView.Put(ctx, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	// Standby/replica invalidation nils the client with no re-initialisation.
+	b.invalidate(ctx, "config")
+
+	// Reading config/admin fires `go b.sendUsage(...)` and calls getVersion();
+	// before the fix the goroutine dereferenced the nil client and crashed the
+	// whole plugin process.
+	_, _ = b.HandleRequest(ctx, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      configAdminPath,
+		Storage:   config.StorageView,
+	})
+
+	// Let the detached sendUsage goroutine run; with the fix it returns an error
+	// instead of panicking.
+	time.Sleep(200 * time.Millisecond)
+}
+
+// TestSendUsage_NilHTTPClient_DoesNotPanic asserts the non-critical call-home
+// telemetry path is safe when the client is nil. sendUsage is always launched as
+// a detached goroutine, so a panic here would crash the whole plugin process.
+func TestSendUsage_NilHTTPClient_DoesNotPanic(t *testing.T) {
+	b, _ := makeBackend(t)
+	b.reset() // httpClient = nil, as on a standby/replica node after invalidate
+
+	// Runs synchronously here; must return without panicking.
+	b.sendUsage(baseConfiguration{
+		AccessToken:    "dummy-non-empty-token",
+		ArtifactoryURL: "http://myserver.com",
+	}, "unit-test")
+}

--- a/backend.go
+++ b/backend.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/template"
@@ -20,7 +21,7 @@ type backend struct {
 	*framework.Backend
 	configMutex      sync.RWMutex
 	rolesMutex       sync.RWMutex
-	httpClient       *http.Client
+	httpClient       atomic.Pointer[http.Client]
 	usernameProducer template.StringTemplate
 }
 
@@ -116,9 +117,9 @@ func (b *backend) InitializeHttpClient(config *adminConfiguration) {
 			},
 		}
 
-		b.httpClient = &http.Client{Transport: tr}
+		b.httpClient.Store(&http.Client{Transport: tr})
 	} else {
-		b.httpClient = http.DefaultClient
+		b.httpClient.Store(http.DefaultClient)
 	}
 }
 
@@ -133,9 +134,7 @@ func (b *backend) invalidate(ctx context.Context, key string) {
 // reset clears any client configuration for a new
 // backend to be configured
 func (b *backend) reset() {
-	b.configMutex.Lock()
-	defer b.configMutex.Unlock()
-	b.httpClient = nil
+	b.httpClient.Store(nil)
 }
 
 const artifactoryHelp = `


### PR DESCRIPTION
## Summary

`performArtifactory{Get,Post,PostWithJSON,Delete}` can dereference a nil `b.httpClient` and crash the entire plugin process with a SIGSEGV. This happens on standby / performance-standby / replica nodes after a `config` change and is easy to trigger with a `config/*` read.

## Root cause

- `invalidate("config")` -> `reset()` sets `b.httpClient = nil`.
- `b.httpClient` is only (re)initialised by `initialize()` at process start and by `pathConfigUpdate()` on a write. Neither runs on a standby/replica node, so after an invalidation the client stays `nil`.
- `pathConfigRead()` (and other read paths) then run `go b.sendUsage(...)`. That goroutine calls `performArtifactoryPostWithJSON()` -> `b.httpClient.Do(req)` on the nil client. Because the goroutine is unrecovered, the panic crashes the whole plugin process (the go-plugin gRPC server), leaving a dead unix socket and `rpc error: code = Unavailable ... dial unix /tmp/pluginNNNN: no such file` on the Vault side.

## Fix

- `performArtifactory*` load the client once into a local and return an error instead of dereferencing a nil client.
- `b.httpClient` is now an `atomic.Pointer[http.Client]`, so the concurrent `reset()` (writer) and `performArtifactory*` (readers) are race-free. Verified with `go test -race` (a data race was reported before this change). The now-redundant mutex in `reset()` is removed.
- `sendUsage` - the plugin's only detached goroutine (non-critical "call home" telemetry, launched from 11 call sites) - now recovers from panics, so that path can never crash the plugin process again. Defense in depth against the amplification that turned a nil dereference into a full outage.

## Tests

Added `artifactory_nil_httpclient_test.go`:
- `TestPerformArtifactory_NilHTTPClient_ReturnsError` - each helper returns an error (not a panic) when the client is nil.
- `TestConfigReadWithNilHTTPClient_DoesNotCrash` - reads `config/admin` after an invalidation and asserts the process survives (SIGSEGVs before the fix).
- `TestSendUsage_NilHTTPClient_DoesNotPanic` - the telemetry path is safe with a nil client.

`go test ./...` and `go test -race` pass; existing tests unaffected.

## Notes

- No functional/API change; the fix is defensive.
- `CHANGELOG.md` updated with an `Unreleased` header (master's CHANGELOG currently tops out at `1.8.5` while tags reach `v1.8.9`); happy to set a specific version (e.g. `1.8.10`) if preferred.
